### PR TITLE
chore: Enable sourceMap in TypeScript configuration

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -14,6 +14,7 @@
     },
     "strict": true,
     "esModuleInterop": true,
+    "sourceMap": true,
     "skipLibCheck": true,
     "types": [
       "node",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,6 +10,7 @@
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "sourceMap": true,
     "allowImportingTsExtensions": true,
     "types": [
       "node",

--- a/palette-types/tsconfig.json
+++ b/palette-types/tsconfig.json
@@ -3,7 +3,8 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "./dist",
-    "strict": true
+    "strict": true,
+    "sourceMap": true,
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
This small PR adds source mapping to the TypeScript configuration. This will allow developers to run code in debuggers for an easier debugging experience. 